### PR TITLE
Using selectors instead of strings for macros and constructos for a b…

### DIFF
--- a/CTXPropertyMapper.podspec
+++ b/CTXPropertyMapper.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   
   spec.name     = 'CTXPropertyMapper'
-  spec.version  = '1.2.4'
+  spec.version  = '1.3.0'
   spec.summary  = 'Simple and highly extensible two ways property mapper'
   spec.homepage = "https://github.com/ef-ctx/CTXPropertyMapper"
   

--- a/CTXPropertyMapper/CTXPropertyDescriptor.h
+++ b/CTXPropertyMapper/CTXPropertyDescriptor.h
@@ -8,13 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
-#define CTXProperty(property) ({[[CTXPropertyDescriptor alloc] initWithPropertyName:@#property];})
-#define CTXPropertyEncode(property) ({[[CTXPropertyDescriptor alloc] initWithPropertyName:@#property mode:CTXPropertyMapperCodificationModeEncode];})
-#define CTXPropertyDecode(property) ({[[CTXPropertyDescriptor alloc] initWithPropertyName:@#property mode:CTXPropertyMapperCodificationModeDecode];})
-#define CTXClass(property, clazz) ({[[CTXPropertyDescriptor alloc] initWithPropertyName:@#property withClass:clazz];})
-#define CTXClassEncode(property, clazz) ({[[CTXPropertyDescriptor alloc] initWithPropertyName:@#property withClass:clazz mode:CTXPropertyMapperCodificationModeEncode];})
-#define CTXClassDecode(property, clazz) ({[[CTXPropertyDescriptor alloc] initWithPropertyName:@#property withClass:clazz mode:CTXPropertyMapperCodificationModeDecode];})
-#define CTXBlock(property, encoder, decoder) ({[[CTXPropertyDescriptor alloc] initWithPropertyName:@#property encondingBlock:encoder decodingBlock:decoder];})
+#define CTXProperty(property) ({[[CTXPropertyDescriptor alloc] initWithSelector:@selector(property)];})
+#define CTXPropertyEncode(property) ({[[CTXPropertyDescriptor alloc] initWithSelector:@selector(property) mode:CTXPropertyMapperCodificationModeEncode];})
+#define CTXPropertyDecode(property) ({[[CTXPropertyDescriptor alloc] initWithSelector:@selector(property) mode:CTXPropertyMapperCodificationModeDecode];})
+#define CTXClass(property, clazz) ({[[CTXPropertyDescriptor alloc] initWithSelector:@selector(property) withClass:clazz];})
+#define CTXClassEncode(property, clazz) ({[[CTXPropertyDescriptor alloc] initWithSelector:@selector(property) withClass:clazz mode:CTXPropertyMapperCodificationModeEncode];})
+#define CTXClassDecode(property, clazz) ({[[CTXPropertyDescriptor alloc] initWithSelector:@selector(property) withClass:clazz mode:CTXPropertyMapperCodificationModeDecode];})
+#define CTXBlock(property, encoder, decoder) ({[[CTXPropertyDescriptor alloc] initWithSelector:@selector(property) encondingBlock:encoder decodingBlock:decoder];})
 #define CTXGenerationConsumerBlock(encoder, decoder) ({[[CTXPropertyDescriptor alloc] initWithEncodingGenerationBlock:encoder decodingConsumerBlock:decoder];})
 
 typedef NS_ENUM(NSUInteger, CTXPropertyMapperCodificationMode) {
@@ -46,11 +46,11 @@ typedef void(^CTXValueConsumerBlock)(id input, id object);
 @property (nonatomic, readonly) enum CTXPropertyMapperCodificationMode mode;
 @property (nonatomic, readonly) enum CTXPropertyDescriptorType type;
 
-- (instancetype)initWithPropertyName:(NSString *)propertyName;
-- (instancetype)initWithPropertyName:(NSString *)propertyName mode:(enum CTXPropertyMapperCodificationMode)mode;
-- (instancetype)initWithPropertyName:(NSString *)propertyName withClass:(Class)clazz;
-- (instancetype)initWithPropertyName:(NSString *)propertyName withClass:(Class)clazz mode:(enum CTXPropertyMapperCodificationMode)mode;
-- (instancetype)initWithPropertyName:(NSString *)propertyName encondingBlock:(CTXValueTransformerBlock)encoder decodingBlock:(CTXValueTransformerBlock)decoder;
+- (instancetype)initWithSelector:(SEL)selector;
+- (instancetype)initWithSelector:(SEL)selector mode:(enum CTXPropertyMapperCodificationMode)mode;
+- (instancetype)initWithSelector:(SEL)selector withClass:(Class)clazz;
+- (instancetype)initWithSelector:(SEL)selector withClass:(Class)clazz mode:(enum CTXPropertyMapperCodificationMode)mode;
+- (instancetype)initWithSelector:(SEL)selector encondingBlock:(CTXValueTransformerBlock)encoder decodingBlock:(CTXValueTransformerBlock)decoder;
 - (instancetype)initWithEncodingGenerationBlock:(CTXValueGenerationBlock)encoder decodingConsumerBlock:(CTXValueConsumerBlock)decoder;
 
 - (void)addValidatorWithName:(NSString *)name validation:(BOOL (^)(id value))validator;

--- a/CTXPropertyMapper/CTXPropertyDescriptor.m
+++ b/CTXPropertyMapper/CTXPropertyDescriptor.m
@@ -28,30 +28,30 @@
     return nil;
 }
 
-- (instancetype)initWithPropertyName:(NSString *)propertyName
+- (instancetype)initWithSelector:(SEL)selector
 {
-    return [self initWithPropertyName:propertyName mode:CTXPropertyMapperCodificationModeEncodeAndDecode];
+    return [self initWithSelector:selector mode:CTXPropertyMapperCodificationModeEncodeAndDecode];
 }
 
-- (instancetype)initWithPropertyName:(NSString *)propertyName mode:(enum CTXPropertyMapperCodificationMode)mode
+- (instancetype)initWithSelector:(SEL)selector mode:(enum CTXPropertyMapperCodificationMode)mode
 {
     if (self = [super init]) {
-        _propertyName = propertyName;
+        _propertyName = NSStringFromSelector(selector);
         _type = CTXPropertyDescriptorTypeDirect;
         _mode = mode;
     }
     return self;
 }
 
-- (instancetype)initWithPropertyName:(NSString *)propertyName withClass:(Class)clazz
+- (instancetype)initWithSelector:(SEL)selector withClass:(Class)clazz
 {
-    return [self initWithPropertyName:propertyName withClass:clazz mode:CTXPropertyMapperCodificationModeEncodeAndDecode];
+    return [self initWithSelector:selector withClass:clazz mode:CTXPropertyMapperCodificationModeEncodeAndDecode];
 }
 
-- (instancetype)initWithPropertyName:(NSString *)propertyName withClass:(Class)clazz mode:(enum CTXPropertyMapperCodificationMode)mode
+- (instancetype)initWithSelector:(SEL)selector withClass:(Class)clazz mode:(enum CTXPropertyMapperCodificationMode)mode
 {
     if (self = [super init]) {
-        _propertyName = propertyName;
+        _propertyName = NSStringFromSelector(selector);
         _propertyClass = clazz;
         _type = CTXPropertyDescriptorTypeClass;
         _mode = mode;
@@ -59,10 +59,10 @@
     return self;
 }
 
-- (instancetype)initWithPropertyName:(NSString *)propertyName encondingBlock:(CTXValueTransformerBlock)encoder decodingBlock:(CTXValueTransformerBlock)decoder
+- (instancetype)initWithSelector:(SEL)selector encondingBlock:(CTXValueTransformerBlock)encoder decodingBlock:(CTXValueTransformerBlock)decoder
 {
     if (self = [super init]) {
-        _propertyName = propertyName;
+        _propertyName = NSStringFromSelector(selector);
         _type = CTXPropertyDescriptorTypeSymmetricalBlock;
         _encodingBlock = encoder;
         _decodingBlock = decoder;

--- a/CTXPropertyMapper/CTXPropertyMapper.m
+++ b/CTXPropertyMapper/CTXPropertyMapper.m
@@ -110,10 +110,10 @@
 	}
 	
     if (!mappingError) {
-        if (!self.mappingsByClass[[clazz description]]) {
-            self.mappingsByClass[[clazz description]] = [NSMutableDictionary dictionary];
+        if (!self.mappingsByClass[NSStringFromClass(clazz)]) {
+            self.mappingsByClass[NSStringFromClass(clazz)] = [NSMutableDictionary dictionary];
         }
-        [self.mappingsByClass[[clazz description]] addEntriesFromDictionary:mappings];
+        [self.mappingsByClass[NSStringFromClass(clazz)] addEntriesFromDictionary:mappings];
     }
     
     return !mappingError;
@@ -150,7 +150,7 @@
 	}
 	
 	if (!mappingError) {
-		self.mappingsByClass[[clazz description]] = [mappings copy];
+		self.mappingsByClass[NSStringFromClass(clazz)] = [mappings copy];
 	}
 	
 	return !mappingError;
@@ -158,32 +158,32 @@
 
 - (void)setFinalMappingEncoder:(CTXFinalMappingEncoderBlock)encoder forClass:(Class)clazz
 {
-	[self.finalMappingEncodersByClass setObject:encoder forKey:[clazz description]];
+	[self.finalMappingEncodersByClass setObject:encoder forKey:NSStringFromClass(clazz)];
 }
 
 - (void)setFinalMappingDecoder:(CTXFinalMappingDecoderBlock)decoder forClass:(Class)clazz withOption:(CTXPropertyMapperFinalMappingDecoderOption)option
 {
-	[self.finalMappingDecodersByClass setObject:decoder forKey:[clazz description]];
-	[self.finalMappingDecoderOptionByClass setObject:@(option) forKey:[clazz description]];
+	[self.finalMappingDecodersByClass setObject:decoder forKey:NSStringFromClass(clazz)];
+	[self.finalMappingDecoderOptionByClass setObject:@(option) forKey:NSStringFromClass(clazz)];
 }
 
 - (BOOL)removeMappingsForClass:(Class)clazz
 {
 	BOOL success = NO;
 	
-	if (self.mappingsByClass[[clazz description]]) {
-		[self.mappingsByClass removeObjectForKey:[clazz description]];
+	if (self.mappingsByClass[NSStringFromClass(clazz)]) {
+		[self.mappingsByClass removeObjectForKey:NSStringFromClass(clazz)];
 		success = YES;
 	}
 	
-	if([self.finalMappingEncodersByClass objectForKey:[clazz description]]) {
-		[self.finalMappingEncodersByClass removeObjectForKey:[clazz description]];
+	if([self.finalMappingEncodersByClass objectForKey:NSStringFromClass(clazz)]) {
+		[self.finalMappingEncodersByClass removeObjectForKey:NSStringFromClass(clazz)];
 		success = YES;
 	}
 	
-	if([self.finalMappingDecodersByClass objectForKey:[clazz description]]) {
-		[self.finalMappingDecodersByClass removeObjectForKey:[clazz description]];
-		[self.finalMappingDecoderOptionByClass removeObjectForKey:[clazz description]];
+	if([self.finalMappingDecodersByClass objectForKey:NSStringFromClass(clazz)]) {
+		[self.finalMappingDecodersByClass removeObjectForKey:NSStringFromClass(clazz)];
+		[self.finalMappingDecoderOptionByClass removeObjectForKey:NSStringFromClass(clazz)];
 		success = YES;
 	}
 	
@@ -197,12 +197,11 @@
 
 - (id)createObjectWithClass:(Class)clazz fromDictionary:(NSDictionary *)dictionary errors:(NSArray *__autoreleasing*)errors
 {
-    NSDictionary *mappings = self.mappingsByClass[clazz.description];
+    NSDictionary *mappings = self.mappingsByClass[NSStringFromClass(clazz)];
     NSArray *validationErrors = nil;
     
     if (!mappings) {
-        NSString *description = [NSString stringWithFormat:CTXPropertyMapperErrorDescription(CTXPropertyMapperErrorCodeMapperDidNotFound),
-                                 [clazz description]];
+        NSString *description = [NSString stringWithFormat:CTXPropertyMapperErrorDescription(CTXPropertyMapperErrorCodeMapperDidNotFound), NSStringFromClass(clazz)];
         
         NSError *error = [NSError errorWithDomain:kCTXPropertyMapperErrorDomain
                                              code:CTXPropertyMapperErrorCodeMapperDidNotFound
@@ -235,7 +234,7 @@
 		return nil;
 	}
 	
-    NSDictionary *mappings = self.mappingsByClass[[object class].description];
+    NSDictionary *mappings = self.mappingsByClass[NSStringFromClass([object class])];
     NSMutableDictionary *exportedObject = [NSMutableDictionary dictionary];
     
     [mappings enumerateKeysAndObjectsUsingBlock:^(NSString *key, CTXPropertyDescriptor *descriptor, BOOL *stop) {
@@ -291,7 +290,7 @@
         }
     }];
 	
-	CTXFinalMappingEncoderBlock encoder = [self.finalMappingEncodersByClass objectForKey:[object class].description];
+	CTXFinalMappingEncoderBlock encoder = [self.finalMappingEncodersByClass objectForKey:NSStringFromClass([object class])];
 	if(encoder) {
 		NSMutableDictionary *mutableExportedObject = [exportedObject ctx_mutableDeepCopy];
 		encoder(mutableExportedObject, object);
@@ -313,7 +312,7 @@
         NSString *type = properties[property];
         
         if ([allowedTypes containsObject:type]) {
-            [mappings setValue:[[CTXPropertyDescriptor alloc] initWithPropertyName:property] forKey:property];
+            [mappings setValue:[[CTXPropertyDescriptor alloc] initWithSelector:NSSelectorFromString(property)] forKey:property];
         }
     }
     
@@ -324,7 +323,7 @@
 {
     NSMutableDictionary *mappings = [NSMutableDictionary dictionary];
     for (NSString *key in keys) {
-        [mappings setValue:[[CTXPropertyDescriptor alloc] initWithPropertyName:key] forKey:key];
+        [mappings setValue:[[CTXPropertyDescriptor alloc] initWithSelector:NSSelectorFromString(key)] forKey:key];
     }
     return mappings;
 }
@@ -333,7 +332,7 @@
 
 - (NSDictionary *)_propertiesForClass:(Class)clazz
 {
-    NSDictionary *properties = self.cachedPropertiesByClass[[clazz description]];
+    NSDictionary *properties = self.cachedPropertiesByClass[NSStringFromClass(clazz)];
     
     if (!properties) {
         
@@ -347,7 +346,7 @@
         
         properties = mutableDictionary;
         
-        self.cachedPropertiesByClass[[clazz description]] = properties;
+        self.cachedPropertiesByClass[NSStringFromClass(clazz)] = properties;
     }
     
     return properties;
@@ -375,11 +374,11 @@
     if ([value isKindOfClass:NSArray.class]) {
         NSDictionary *properties = [self _propertiesForClass:[object class]];
         //TODO: Actually doesn't support subclasses of the follow entities
-        if ([properties[key] isEqualToString:[NSArray description]] || [properties[key] isEqualToString:[NSMutableArray description]]) {
+        if ([properties[key] isEqualToString:NSStringFromClass([NSArray class])] || [properties[key] isEqualToString:NSStringFromClass([NSMutableArray class])]) {
             [object setValue:value forKey:key];
-        } else if ([properties[key] isEqualToString:[NSSet description]] || [properties[key] isEqualToString:[NSMutableSet description]]) {
+        } else if ([properties[key] isEqualToString:NSStringFromClass([NSSet class])] || [properties[key] isEqualToString:NSStringFromClass([NSMutableSet class])]) {
             [object setValue:[NSMutableSet setWithArray:value] forKey:key];
-        } else if ([properties[key] isEqualToString:[NSOrderedSet description]] || [properties[key] isEqualToString:[NSMutableOrderedSet description]]){
+        } else if ([properties[key] isEqualToString:NSStringFromClass([NSOrderedSet class])] || [properties[key] isEqualToString:NSStringFromClass([NSMutableOrderedSet class])]){
             [object setValue:[NSMutableOrderedSet orderedSetWithArray:value] forKey:key];
         }
         
@@ -395,7 +394,7 @@
 		return nil;
 	}
 	
-    NSDictionary *mappings = self.mappingsByClass[[clazz description]];
+    NSDictionary *mappings = self.mappingsByClass[NSStringFromClass(clazz)];
     
     id instance = [self.modelFactory instanceForClass:clazz withDictionary:dictionary];
     
@@ -434,9 +433,9 @@
     }];
 	
 	
-	CTXFinalMappingDecoderBlock finalDecoder = [self.finalMappingDecodersByClass objectForKey:[clazz description]];
+	CTXFinalMappingDecoderBlock finalDecoder = [self.finalMappingDecodersByClass objectForKey:NSStringFromClass(clazz)];
 	if(finalDecoder) {
-		CTXPropertyMapperFinalMappingDecoderOption finalDecoderOption = [[self.finalMappingDecoderOptionByClass objectForKey:[clazz description]] unsignedIntegerValue];
+		CTXPropertyMapperFinalMappingDecoderOption finalDecoderOption = [[self.finalMappingDecoderOptionByClass objectForKey:NSStringFromClass(clazz)] unsignedIntegerValue];
 		
 		if(finalDecoderOption == CTXPropertyMapperFinalMappingDecoderOptionIncludeAllKeys) {
 			finalDecoder(dictionary, instance);
@@ -484,7 +483,7 @@
 			*stop = YES;
 		} else if (descriptor.type != CTXPropertyDescriptorTypeAsymmetricalBlock && !properties[descriptor.propertyName]) {
 			NSString *author = [NSString stringWithFormat:CTXPropertyMapperErrorDescription(CTXPropertyMapperErrorCodeUnknownProperty),
-								descriptor.propertyName, [clazz description]];
+								descriptor.propertyName, NSStringFromClass(clazz)];
 			mappingError = [NSError errorWithDomain:kCTXPropertyMapperErrorDomain
 											   code:CTXPropertyMapperErrorCodeUnknownProperty
 										   userInfo:@{NSLocalizedDescriptionKey:author}];
@@ -543,7 +542,7 @@
         switch (descriptor.type) {
             case CTXPropertyDescriptorTypeClass:
             {
-                NSDictionary *subMapping = self.mappingsByClass[[descriptor.propertyClass description]];
+                NSDictionary *subMapping = self.mappingsByClass[NSStringFromClass(descriptor.propertyClass)];
                 
                 if (subMapping) {
                     NSArray *validationErrors = [self _validateMapping:subMapping withValues:value];
@@ -551,7 +550,7 @@
                         [errors addObjectsFromArray:validationErrors];
                     }
                 } else {
-                    NSString *description = [NSString stringWithFormat:CTXPropertyMapperErrorDescription(CTXPropertyMapperErrorCodeMapperDidNotFound), [descriptor.propertyClass description]];
+                    NSString *description = [NSString stringWithFormat:CTXPropertyMapperErrorDescription(CTXPropertyMapperErrorCodeMapperDidNotFound), NSStringFromClass(descriptor.propertyClass)];
                     
                     NSError *error = [NSError errorWithDomain:kCTXPropertyMapperErrorDomain
                                                          code:CTXPropertyMapperErrorCodeMapperDidNotFound


### PR DESCRIPTION
…it more safety. Replaced all class description calls with NSStringFromClass